### PR TITLE
removed the p tag saying Content???? where for art thou content??

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -65,7 +65,6 @@
         <div class="p-5 mb-4 bg-dark text-bg-dark rounded-3">
           <div class="container-fluid py-5">
             <h1 class="display-5 fw-bold">Domestic & General API Developer Portal</h1>
-            <p class="col-md-8 fs-4">Content????...</p>
           </div>
         </div>
         <div class="row align-items-md-stretch">

--- a/tmpl/index.html
+++ b/tmpl/index.html
@@ -65,7 +65,6 @@
         <div class="p-5 mb-4 bg-dark text-bg-dark rounded-3">
           <div class="container-fluid py-5">
             <h1 class="display-5 fw-bold">Domestic & General API Developer Portal</h1>
-            <p class="col-md-8 fs-4">Content????...</p>
           </div>
         </div>
         <div class="row align-items-md-stretch">


### PR DESCRIPTION
# What?

_What did you change specifically?_

removes this:

![Screenshot 2024-09-12 at 07 18 07](https://github.com/user-attachments/assets/1535e892-36a2-4184-b9b8-639a8948f5bd)

now:

![Screenshot 2024-09-12 at 07 18 58](https://github.com/user-attachments/assets/4b7596a0-2b6c-4850-99b2-e6f75026d6b0)

# Why?

_Why did these things change? Give some explanation add a link to a Jira ticket etc_

Doesn't look professional - we can pretty things up later but I think for now its fine just if we remove this div - thats my decision as chief technical design officer anyway
